### PR TITLE
bestSeller 사진 존재하지않으면 보여주지않는 것으로 변경.

### DIFF
--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -184,8 +184,9 @@
                         <!-- 이미지 영역 -->
                         <div class="col-md-6">
                             <figure class="products-thumb">
-                                <img th:src="${mostSellerBook != null && mostSellerBook.imgPath != null ? mostSellerBook.imgPath : '/static/images/default.jpg'}" alt="book" class="single-image">
-                                     alt="book" class="single-image">
+                                <div th:if="${mostSellerBook != null && mostSellerBook.imgPath != null}">
+                                    <img th:src="${mostSellerBook.imgPath}" alt="book" class="single-image">
+                                </div>
                             </figure>
                         </div>
 


### PR DESCRIPTION
- 홈에서 bestSeller의 이미지 존재하지않으면 기본이미지 보여주도록 했는데 , static 에 존재하는 파일을 잘 못불러들여서 오류가 계속 났음.