### PR TITLE
feat: add pointPolicyId

### DIFF
--- a/src/main/java/store/aurora/point/dto/PointPolicyRequest.java
+++ b/src/main/java/store/aurora/point/dto/PointPolicyRequest.java
@@ -1,5 +1,7 @@
 package store.aurora.point.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,6 +12,7 @@ import java.math.BigDecimal;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PointPolicyRequest {
+    @NotNull @Min(1) private Integer pointPolicyId;
     private String pointPolicyName;
     private String pointPolicyType; // Enum 타입 (AMOUNT, PERCENTAGE)
     private BigDecimal pointPolicyValue;

--- a/src/main/resources/templates/admin/point-policy/point-policies.html
+++ b/src/main/resources/templates/admin/point-policy/point-policies.html
@@ -29,6 +29,7 @@
                             <table>
                                 <thead>
                                 <tr>
+                                    <th>정책 아이디</th>
                                     <th>정책 이름</th>
                                     <th>정책 유형</th>
                                     <th>포인트 값</th>
@@ -39,6 +40,7 @@
                                 <tbody>
                                 <tr th:each="policy : ${pointPolicies}"
                                     th:classappend="${!policy.isActive} ? 'text-decoration-line-through text-muted' : ''">
+                                    <td th:text="${policy.id}"></td>
                                     <td th:text="${policy.pointPolicyName}">Sample Policy</td>
                                     <td th:text="${policy.pointPolicyType}">FIXED</td>
 

--- a/src/main/resources/templates/admin/point-policy/point-policy-form.html
+++ b/src/main/resources/templates/admin/point-policy/point-policy-form.html
@@ -28,6 +28,11 @@
 
               <form th:action="@{/admin/point-policies/add}" method="post">
                 <div class="mb-3">
+                  <label for="pointPolicyId" class="form-label align-left">포인트 정책 아이디</label>
+                  <input type="number" id="pointPolicyId" name="pointPolicyId" class="form-control" placeholder="예: 1" required min="1">
+                </div>
+
+                <div class="mb-3">
                   <label for="pointPolicyName" class="form-label align-left">포인트 정책 이름</label>
                   <input type="text" id="pointPolicyName" name="pointPolicyName" class="form-control" placeholder="예: 회원가입 보너스" required>
                 </div>


### PR DESCRIPTION
포인트 정책 목록 페이지와 포인트 정책 등록 페이지에 포인트 정책 아이디 추가를 추가하였습니다.
이유 : 포인트 정책 이름이 포인트 정책 아이디로 포인트 정책을 식별하기 위해