### PR TITLE
jwt 인증 수정

### DIFF
--- a/src/main/java/store/aurora/common/CookieUtil.java
+++ b/src/main/java/store/aurora/common/CookieUtil.java
@@ -42,8 +42,6 @@ public class CookieUtil {
         for (Cookie cookie : cookies) {
             if (cookie.getName().equals(cookieName)
                     && Objects.nonNull(cookie.getValue())
-                    && !cookie.getValue().isEmpty()
-                    && !cookie.getValue().isBlank()
             ) {
                 return cookie.getValue();  // 쿠키 이름이 일치하면 반환
             }

--- a/src/main/java/store/aurora/config/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/store/aurora/config/security/filter/JwtAuthenticationFilter.java
@@ -70,7 +70,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         response.sendRedirect(LOGIN_URL);
                         return;
                     }
-                } else {
+                } else { //case 1: access 변조
                     response.sendRedirect("/logout");
                     return;
                 }


### PR DESCRIPTION
수정 전 : 사용자가 access 쿠키 값 지우면 access 토큰 변조로 간주해서 access/refresh 쿠키 다 삭제 해줘야 하는데 인증이 필요없는 페이지에서 그게 안됐음

> 원인 : access 쿠키는 있는데 값이 없는 경우와 access 쿠키 자체가 없는 것과 같게 처리됨 

            (->쿠키 가져오는 유틸 메서드가 둘 다 null을 반환해서)
수정 후 : 위 경우 로그아웃 처리함